### PR TITLE
Add Nix Flakes support with crane

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,44 @@ stashi is a CLI app that uses GMO Coin’s API to automate cryptocurrency accumu
 
 ## Installation
 
+### Using cargo
+
 Install stashi using cargo:
 
 ```bash
 $ cargo install --git https://github.com/erechorse/stashi.git
+```
+
+### Using Nix
+
+If you have Nix with flakes enabled, you can install stashi directly:
+
+```bash
+$ nix profile install github:erechorse/stashi
+```
+
+Or run it without installing:
+
+```bash
+$ nix run github:erechorse/stashi -- check /path/to/config.toml
+```
+
+You can also use it as a flake input in your own flake:
+
+```nix
+{
+  inputs.stashi.url = "github:erechorse/stashi";
+
+  outputs = { self, stashi, ... }: {
+    # Use stashi.packages.${system}.default or stashi.packages.${system}.stashi
+  };
+}
+```
+
+For development, you can use the provided devShell:
+
+```bash
+$ nix develop
 ```
 
 ## Configuration

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,64 @@
+{
+  "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1774313767,
+        "narHash": "sha256-hy0XTQND6avzGEUFrJtYBBpFa/POiiaGBr2vpU6Y9tY=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "3d9df76e29656c679c744968b17fbaf28f0e923d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1772408722,
+        "narHash": "sha256-rHuJtdcOjK7rAHpHphUb1iCvgkU3GpfvicLMwwnfMT0=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "f20dc5d9b8027381c474144ecabc9034d6a839a3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1774709303,
+        "narHash": "sha256-D3Q07BbIA2KnTcSXIqqu9P586uWxN74zNoCH3h2ESHg=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "8110df5ad7abf5d4c0f6fb0f8f978390e77f9685",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "crane": "crane",
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,67 @@
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    crane = {
+      url = "github:ipetkov/crane";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    flake-parts = {
+      url = "github:hercules-ci/flake-parts";
+      inputs.nixpkgs-lib.follows = "nixpkgs";
+    };
+  };
+
+  outputs = inputs:
+    inputs.flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+      perSystem = { self', pkgs, system, ... }:
+        let
+          craneLib = inputs.crane.mkLib pkgs;
+
+          src = craneLib.cleanCargoSource ./.;
+
+          nativeBuildInputs = with pkgs; [ pkg-config cacert ];
+
+          buildInputs = with pkgs; [
+            openssl
+          ] ++ lib.optionals stdenv.isDarwin [
+            libiconv
+            darwin.apple_sdk.frameworks.Security
+            darwin.apple_sdk.frameworks.SystemConfiguration
+          ];
+
+          commonArgs = {
+            inherit src buildInputs nativeBuildInputs;
+          };
+
+          cargoArtifacts = craneLib.buildDepsOnly commonArgs;
+
+          stashi = craneLib.buildPackage (commonArgs // {
+            inherit cargoArtifacts;
+          });
+        in
+        {
+          checks = {
+            inherit stashi;
+          };
+
+          packages.default = stashi;
+          packages.stashi = stashi;
+
+          devShells.default = craneLib.devShell {
+            checks = self'.checks;
+            packages = with pkgs; [
+              cargo
+              rustc
+              rustfmt
+              clippy
+            ];
+          };
+        };
+    };
+}


### PR DESCRIPTION
- Add flake.nix with crane-based Rust build
- Support x86_64/aarch64 Linux and macOS
- Add cacert for HTTPS certificate handling in tests
- Update README.md with Nix installation instructions